### PR TITLE
Replace help2man command with a no-op

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -32,10 +32,10 @@ share {
       s{\@pkgdatadir\@}{\$prefix/share/libtool}g;
       s{\@aclocaldir\@}{\$prefix/share/aclocal}g;
     });
-    foreach my $man (map { Path::Tiny->new($_) } qw( doc/libtool.1 doc/libtoolize.1 ))
-    {
-      $man->touch;
-    }
+    my($makefile) = Path::Tiny->new('Makefile.in');
+    $makefile->edit_lines(sub {
+      s{\@HELP2MAN\@}{perl -e1 --}g;
+    });
   };
   
   meta->after_hook(


### PR DESCRIPTION
This allows the build to proceed without having to have actually
regenerate the documentation.

Note that we use `perl` directly here instead of `$^X` to avoid having
to deal with full paths that may need escaping under Windows.